### PR TITLE
Add a local copy of the license for NuGet to build

### DIFF
--- a/src/Jellyfin.XmlTv/Jellyfin.XmlTv.csproj
+++ b/src/Jellyfin.XmlTv/Jellyfin.XmlTv.csproj
@@ -9,13 +9,17 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.XmlTv</PackageId>
-    <PackageLicenseFile>../../LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/jellyfin/Jellyfin.XmlTv</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
+<ItemGroup>
+    <None Include="LICENSE" Pack="true" PackagePath="" />
+</ItemGroup>
 
   <!-- Code analyzers -->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Jellyfin.XmlTv/LICENSE
+++ b/src/Jellyfin.XmlTv/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Alex Stevens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This corrects a license not found error.