### PR TITLE
Fix for Guide Loading Issue

### DIFF
--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -586,13 +586,14 @@ namespace Jellyfin.XmlTv
 
         public void ParseEpisodeDataForOnScreen(XmlReader reader, XmlTvProgram result)
         {
-            _ = reader;
-            _ = result;
+            reader.Skip();
+            // _ = reader;
+            // _ = result;
 
             // example: 'Episode #FFEE'
             // TODO: This could be textual - how do we populate an Int32
 
-            // var value = reader.ReadElementContentAsString();
+            //  var value = reader.ReadElementContentAsString();
             // value = HttpUtility.HtmlDecode(value);
             // value = value.Replace(" ", "");
 

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -593,7 +593,7 @@ namespace Jellyfin.XmlTv
             // example: 'Episode #FFEE'
             // TODO: This could be textual - how do we populate an Int32
 
-            //  var value = reader.ReadElementContentAsString();
+            // var value = reader.ReadElementContentAsString();
             // value = HttpUtility.HtmlDecode(value);
             // value = value.Replace(" ", "");
 


### PR DESCRIPTION
**Changes**
Changes the episode number parser to skip when `system="onscreen"`. Allows guides with this parameter to finish loading correctly.

**Issues**
Fixes #2.
Fixes https://github.com/jellyfin/jellyfin/issues/1932.