### PR TITLE
Update and Fix Errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/tests/Jellyfin.XmlTv.Tests/bin/Debug/netcoreapp3.0/Jellyfin.XmlTv.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/tests/Jellyfin.XmlTv.Tests",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/tests/Jellyfin.XmlTv.Tests/Jellyfin.XmlTv.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/tests/Jellyfin.XmlTv.Tests/Jellyfin.XmlTv.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/tests/Jellyfin.XmlTv.Tests/Jellyfin.XmlTv.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Jellyfin.XmlTv/Entities/XmlTvChannel.cs
+++ b/src/Jellyfin.XmlTv/Entities/XmlTvChannel.cs
@@ -39,7 +39,7 @@ namespace Jellyfin.XmlTv.Entities
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => Id.GetHashCode() * 17;
+            => Id.GetHashCode(StringComparison.InvariantCulture) * 17;
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Jellyfin.XmlTv/Entities/XmlTvChannel.cs
+++ b/src/Jellyfin.XmlTv/Entities/XmlTvChannel.cs
@@ -39,7 +39,7 @@ namespace Jellyfin.XmlTv.Entities
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => Id.GetHashCode(StringComparison.InvariantCulture) * 17;
+            => Id.GetHashCode(StringComparison.Ordinal) * 17;
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
+++ b/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
@@ -86,7 +86,7 @@ namespace Jellyfin.XmlTv.Entities
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => (ChannelId.GetHashCode() * 17) + (StartDate.GetHashCode() * 17) + (EndDate.GetHashCode() * 17);
+            => (ChannelId.GetHashCode(StringComparison.InvariantCulture) * 17) + (StartDate.GetHashCode() * 17) + (EndDate.GetHashCode() * 17);
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
+++ b/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
@@ -86,7 +86,7 @@ namespace Jellyfin.XmlTv.Entities
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => (ChannelId.GetHashCode(StringComparison.InvariantCulture) * 17) + (StartDate.GetHashCode() * 17) + (EndDate.GetHashCode() * 17);
+            => (ChannelId.GetHashCode(StringComparison.Ordinal) * 17) + (StartDate.GetHashCode() * 17) + (EndDate.GetHashCode() * 17);
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Jellyfin.XmlTv/Jellyfin.XmlTv.csproj
+++ b/src/Jellyfin.XmlTv/Jellyfin.XmlTv.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -409,7 +409,7 @@ namespace Jellyfin.XmlTv
             if (reader.Name == "value")
             {
                 var textValue = reader.ReadElementContentAsString();
-                int index = textValue.IndexOf('/');
+                int index = textValue.IndexOf('/', StringComparison.InvariantCulture);
                 if (index != -1)
                 {
                     var substring = textValue.Substring(index);
@@ -471,7 +471,7 @@ namespace Jellyfin.XmlTv
                     ParseEpisodeDataForXmlTvNs(reader, result);
                     break;
                 case "onscreen":
-                    ParseEpisodeDataForOnScreen(reader, result);
+                    ParseEpisodeDataForOnScreen(reader);
                     break;
                 case "thetvdb.com":
                     ParseTvdbSystem(reader, result);
@@ -584,7 +584,7 @@ namespace Jellyfin.XmlTv
             }
         }
 
-        public void ParseEpisodeDataForOnScreen(XmlReader reader, XmlTvProgram result)
+        public void ParseEpisodeDataForOnScreen(XmlReader reader)
         {
             reader.Skip();
             // _ = reader;
@@ -618,7 +618,7 @@ namespace Jellyfin.XmlTv
         {
             var value = reader.ReadElementContentAsString();
 
-            value = value.Replace(" ", string.Empty);
+            value = value.Replace(" ", string.Empty, StringComparison.InvariantCulture);
 
             // Episode details
             var components = value.Split('.');

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -409,7 +409,7 @@ namespace Jellyfin.XmlTv
             if (reader.Name == "value")
             {
                 var textValue = reader.ReadElementContentAsString();
-                int index = textValue.IndexOf('/', StringComparison.InvariantCulture);
+                int index = textValue.IndexOf('/', StringComparison.Ordinal);
                 if (index != -1)
                 {
                     var substring = textValue.Substring(index);
@@ -618,7 +618,7 @@ namespace Jellyfin.XmlTv
         {
             var value = reader.ReadElementContentAsString();
 
-            value = value.Replace(" ", string.Empty, StringComparison.InvariantCulture);
+            value = value.Replace(" ", string.Empty, StringComparison.Ordinal);
 
             // Episode details
             var components = value.Split('.');


### PR DESCRIPTION
Updates to netstandard2.1, and fixes some errors for not specifying a string comparison type ([CA1307](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1307?view=vs-2019)). Removes result from ParseEpisodeDataForOnScreen because it's not being used.