### PR TITLE
Use banner image for live TV programs

### DIFF
--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -256,10 +256,14 @@ namespace Jellyfin.XmlTv
 
                                 break;
                             case "icon":
+                                XmlTvIcon icon = ProcessIconNode(xmlProg);
                                 if (result.Icon == null)
                                 {
-                                    XmlTvIcon icon = ProcessIconNode(xmlProg);
-                                    // Set the icon only if the width is greater than the height (i.e. the icon is a banner rather than a poster)
+                                    result.Icon = icon; // If there is no icon set then set the processed icon (which could also be null)
+                                }
+                                else
+                                {
+                                    // If there is already an icon set (which could be a poster) then replace it with a banner
                                     if (icon != null && icon.Width.GetValueOrDefault() > icon.Height.GetValueOrDefault())
                                     {
                                         result.Icon = icon;

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -256,8 +256,18 @@ namespace Jellyfin.XmlTv
 
                                 break;
                             case "icon":
-                                result.Icon = ProcessIconNode(xmlProg);
+                                if (result.Icon == null)
+                                {
+                                    XmlTvIcon icon = ProcessIconNode(xmlProg);
+                                    // Set the icon only if the width is greater than the height (i.e. the icon is a banner rather than a poster)
+                                    if (icon != null && icon.Width.GetValueOrDefault() > icon.Height.GetValueOrDefault())
+                                    {
+                                        result.Icon = icon;
+                                    }
+                                }
+
                                 xmlProg.Skip();
+
                                 break;
                             case "premiere":
                                 ProcessPremiereNode(xmlProg, result);
@@ -769,6 +779,44 @@ namespace Jellyfin.XmlTv
 
         public XmlTvIcon ProcessIconNode(XmlReader reader)
         {
+            /*
+            var isPopulated = false;
+
+            var result = new XmlTvIcon();
+
+            var source = reader.GetAttribute("src");
+            if (!string.IsNullOrEmpty(source))
+            {
+                result.Source = source;
+                isPopulated = true;
+            }
+
+            var widthString = reader.GetAttribute("width");
+            var heightString = reader.GetAttribute("height");
+
+            int? iconWidth = !string.IsNullOrEmpty(widthString) && int.TryParse(widthString, out int width) ? (int?)width : null;
+            int? iconHeight = !string.IsNullOrEmpty(heightString) && int.TryParse(heightString, out int height) ? (int?)height : null;
+
+            if (iconWidth != null && iconHeight != null)
+            {
+                if ((isProgram && iconWidth > iconHeight) || (!isProgram && iconHeight > iconWidth))
+                {
+                    result.Width = iconWidth;
+                    result.Height = iconHeight;
+                    return result;
+                }
+                else
+                {
+                    return isPopulated ? result : null;
+                }
+            }
+            else
+            {
+                return isPopulated ? result : null;
+            }
+
+            */
+
             var result = new XmlTvIcon();
             var isPopulated = false;
 

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -779,44 +779,6 @@ namespace Jellyfin.XmlTv
 
         public XmlTvIcon ProcessIconNode(XmlReader reader)
         {
-            /*
-            var isPopulated = false;
-
-            var result = new XmlTvIcon();
-
-            var source = reader.GetAttribute("src");
-            if (!string.IsNullOrEmpty(source))
-            {
-                result.Source = source;
-                isPopulated = true;
-            }
-
-            var widthString = reader.GetAttribute("width");
-            var heightString = reader.GetAttribute("height");
-
-            int? iconWidth = !string.IsNullOrEmpty(widthString) && int.TryParse(widthString, out int width) ? (int?)width : null;
-            int? iconHeight = !string.IsNullOrEmpty(heightString) && int.TryParse(heightString, out int height) ? (int?)height : null;
-
-            if (iconWidth != null && iconHeight != null)
-            {
-                if ((isProgram && iconWidth > iconHeight) || (!isProgram && iconHeight > iconWidth))
-                {
-                    result.Width = iconWidth;
-                    result.Height = iconHeight;
-                    return result;
-                }
-                else
-                {
-                    return isPopulated ? result : null;
-                }
-            }
-            else
-            {
-                return isPopulated ? result : null;
-            }
-
-            */
-
             var result = new XmlTvIcon();
             var isPopulated = false;
 

--- a/tests/Jellyfin.XmlTv.Tests/Test Data/schedulesdirect.xml
+++ b/tests/Jellyfin.XmlTv.Tests/Test Data/schedulesdirect.xml
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<tv date="7/29/2020 11:00:29 AM" source-info-url="http://schedulesdirect.org" source-info-name="Schedules Direct">
+  <channel id="EPG123.10108.schedulesdirect.org">
+    <display-name>CFTO</display-name>
+    <display-name>CTV Toronto</display-name>
+    <display-name>201 CFTO</display-name>
+    <display-name>201</display-name>
+    <display-name>CTV</display-name>
+    <icon src="s10108_dark_360w_270h.png" width="360" height="270" />
+  </channel>
+  <channel id="EPG123.10091.schedulesdirect.org">
+    <display-name>CBLT</display-name>
+    <display-name>CBLT - CBC Toronto</display-name>
+    <display-name>205 CBLT</display-name>
+    <display-name>205</display-name>
+    <display-name>CBC</display-name>
+    <icon src="s10091_dark_360w_270h.png" width="360" height="270" />
+  </channel>
+    <programme start="20200729000000 +0000" stop="20200729010000 +0000" channel="EPG123.10108.schedulesdirect.org">
+    <title>Match Game</title>
+    <sub-title>Match Game</sub-title>
+    <desc>Celebrity panelists include Tituss Burgess, Jane Krakowski, Sasheer Zamata, Darrell Hammond, Rick Fox and Constance Zimmer.</desc>
+    <credits>
+      <producer>Alec Baldwin</producer>
+      <producer>Jennifer Mullin</producer>
+      <presenter>Alec Baldwin</presenter>
+      <guest>Tituss Burgess</guest>
+      <guest>Jane Krakowski</guest>
+      <guest>Sasheer Zamata</guest>
+      <guest>Darrell Hammond</guest>
+      <guest>Rick Fox</guest>
+      <guest>Constance Zimmer</guest>
+    </credits>
+    <date>20170514</date>
+    <category>Series</category>
+    <category>Game Show</category>
+    <language>en</language>
+    <icon src="p12845677_b_v3_af.jpg" width="270" height="360" />
+    <icon src="p12845677_b_h3_af.jpg" width="360" height="270" />
+    <icon src="p12845677_b_v5_af.jpg" width="240" height="360" />
+    <icon src="p12845677_b_h12_af.jpg" width="960" height="540" />
+    <episode-num system="dd_progid">EP02420905.0022</episode-num>
+    <episode-num system="xmltv_ns">1.11.0/1</episode-num>
+    <audio>
+      <stereo>stereo</stereo>
+    </audio>
+    <previously-shown />
+    <subtitles type="teletext" />
+    <rating system="Canadian Parental Rating">
+      <value>14+</value>
+    </rating>
+    <rating system="USA Parental Rating">
+      <value>TV14</value>
+    </rating>
+    <rating system="VCHIP">
+      <value>TV-14</value>
+    </rating>
+  </programme>
+  <programme start="20200729010000 +0000" stop="20200729020100 +0000" channel="EPG123.10108.schedulesdirect.org">
+    <title>Unforgettable</title>
+    <sub-title>Trajectories</sub-title>
+    <desc>When a second murder occurs at an active crime scene, Al and Carrie wade through hundreds of bystanders to uncover if it was retribution or an unrelated attack.</desc>
+    <credits>
+      <director>Anna Foerster</director>
+      <actor role="Carrie Wells">Poppy Montgomery</actor>
+      <actor role="Det. Al Burns">Dylan Walsh</actor>
+      <actor role="Det. Mike Costello">Michael Gaston</actor>
+      <actor role="Det. Roe Saunders">Kevin Rankin</actor>
+      <actor role="Det. Nina Inara">Daya Vaidya</actor>
+      <writer>Erik Oleson</writer>
+      <producer>Ed Redlich</producer>
+      <producer>John Bellucci</producer>
+      <producer>Sarah Timberman</producer>
+      <producer>Carl Beverly</producer>
+      <guest>Iris Delgado</guest>
+      <guest>Carl Ducena</guest>
+      <guest>Daniel Flaherty</guest>
+      <guest>Robert Funaro</guest>
+      <guest>Cristina J Huie</guest>
+      <guest>Erik Jensen</guest>
+      <guest>C.S. Lee</guest>
+      <guest>Dascha Polanco</guest>
+      <guest>Maria Elena Ramirez</guest>
+      <guest>Jennifer Restivo</guest>
+      <guest>Luke Rosen</guest>
+      <guest>Greg Serano</guest>
+      <guest>Tom Stratford</guest>
+      <guest>Tino Sutras</guest>
+      <guest>Steven Vigil</guest>
+      <guest>Philip E Jones</guest>
+      <guest>Rick Pantera</guest>
+      <guest>Danielle Ricci</guest>
+      <guest>Lj Smith</guest>
+    </credits>
+    <date>20111122</date>
+    <category>Series</category>
+    <category>Crime Drama</category>
+    <language>en</language>
+    <icon src="p8680420_b_v3_bc.jpg" width="270" height="360" />
+    <icon src="p8680420_b_h12_ag.jpg" width="960" height="540" />
+    <icon src="p8680420_b_h3_bc.jpg" width="360" height="270" />
+    <icon src="p8680420_b_v5_bc.jpg" width="240" height="360" />
+    <icon src="p8680420_b_s2_ad.jpg" width="1400" height="1400" />
+    <episode-num system="dd_progid">EP01419807.0010</episode-num>
+    <episode-num system="xmltv_ns">0.9.0/1</episode-num>
+    <audio>
+      <stereo>stereo</stereo>
+    </audio>
+    <previously-shown />
+    <subtitles type="teletext" />
+    <rating system="Canadian Parental Rating">
+      <value>14+</value>
+    </rating>
+    <rating system="USA Parental Rating">
+      <value>TV14</value>
+    </rating>
+    <rating system="VCHIP">
+      <value>TV-14</value>
+    </rating>
+  </programme>
+  </tv>

--- a/tests/Jellyfin.XmlTv.Tests/XmlTvReaderTests.cs
+++ b/tests/Jellyfin.XmlTv.Tests/XmlTvReaderTests.cs
@@ -208,5 +208,29 @@ namespace Jellyfin.XmlTv.Test
                 startDate.AddMonths(1)).ToList();
             Assert.Equal(297, programs.Count);
         }
+
+        [Fact]
+        public void SchedulesDirectTest()
+        {
+            var testFile = Path.Join("Test Data", "schedulesdirect.xml");
+            var reader = new XmlTvReader(testFile, null);
+
+            var channels = reader.GetChannels().ToList();
+
+            // Pick a channel to check the data for
+            var channel = channels.SingleOrDefault(c => c.Id == "EPG123.10108.schedulesdirect.org"); // CTV Toronto
+            Assert.NotNull(channel);
+
+            var startDate = new DateTimeOffset(2020, 07, 29, 0, 0, 0, new TimeSpan());
+            var cancellationToken = new CancellationToken();
+            var programmes = reader.GetProgrammes(channel.Id, startDate, startDate.AddDays(1), cancellationToken).ToList();
+
+            var programme = programmes.SingleOrDefault(p => p.Title == "Match Game");
+            Assert.NotNull(programme.Episode);
+            Assert.True(programme.Credits.Count == 9);
+
+            Assert.NotNull(programme.Icon);
+            Assert.True(programme.Icon.Width > programme.Icon.Height);
+        }
     }
 }


### PR DESCRIPTION
Some Live TV guide data providers (e.g. Schedules Direct) provide program icons in various sizes (banner, poster, etc). Currently, for live TV programs, Jellyfin is using the last icon in the list (which can be a poster). This causes the issue in https://github.com/jellyfin/jellyfin/issues/10893

This PR ensures live TV programs always use the banner size where the image width > image height.