### PR TITLE
Fix element skipping

### DIFF
--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -935,21 +935,24 @@ namespace Jellyfin.XmlTv
              */
 
             var currentElementName = reader.Name;
-            var values = new List<(string? language, string value)>()
-            {
-                (reader.GetAttribute("lang"), reader.ReadElementContentAsString())
-            };
+            var values = new List<(string? language, string value)>();
 
-            while (reader.Read())
+            while (!reader.EOF && reader.ReadState == ReadState.Interactive)
             {
-                if (reader.NodeType == XmlNodeType.Element && reader.Name != currentElementName)
+                if (reader.NodeType == XmlNodeType.Element)
                 {
-                    break;
+                    if (reader.Name == currentElementName)
+                    {
+                        values.Add((reader.GetAttribute("lang"), reader.ReadElementContentAsString()));
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
-
-                if (reader.NodeType == XmlNodeType.Element && reader.Name == currentElementName)
+                else
                 {
-                    values.Add((reader.GetAttribute("lang"), reader.ReadElementContentAsString()));
+                    reader.Read();
                 }
             }
 


### PR DESCRIPTION
The element immediately following a `<category>` element is currently skipped over due to `ReadElementContentAsString()` followed by `reader.Read()`.
In my case this is stopping movie images from working `<category>Movie</category><icon src="..."/>`. 
Rewritten to match the other methods.