### PR TITLE
Make Episode null until series tag is encountered

### DIFF
--- a/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
+++ b/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.XmlTv.Entities
             Credits = new List<XmlTvCredit>();
             Categories = new List<string>();
             Countries = new List<string>();
-            Episode = new XmlTvEpisode();
+            Episode = null;
 
             ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             SeriesProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -47,7 +47,7 @@ namespace Jellyfin.XmlTv.Entities
 
         public DateTimeOffset? CopyrightDate { get; set; }
 
-        public XmlTvEpisode Episode { get; set; }
+        public XmlTvEpisode? Episode { get; set; }
 
         public List<XmlTvCredit> Credits { get; }
 

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -127,7 +127,7 @@ namespace Jellyfin.XmlTv
         private void SetChannelNumber(XmlTvChannel channel, string value)
         {
             value = value.Replace('-', '.');
-            if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var number))
+            if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var _))
             {
                 channel.Number = value;
             }
@@ -463,6 +463,8 @@ namespace Jellyfin.XmlTv
 
         public void ProcessEpisodeNum(XmlReader reader, XmlTvProgram result)
         {
+            result.Episode ??= new XmlTvEpisode();
+
             /*
             <episode-num system="dd_progid">EP00003026.0666</episode-num>
             <episode-num system="onscreen">2706</episode-num>
@@ -515,12 +517,12 @@ namespace Jellyfin.XmlTv
 
                 if (int.TryParse(res.Groups[1].Value, out parsedInt))
                 {
-                    result.Episode.Series = parsedInt;
+                    result.Episode!.Series = parsedInt;
                 }
 
                 if (int.TryParse(res.Groups[2].Value, out parsedInt))
                 {
-                    result.Episode.Episode = parsedInt;
+                    result.Episode!.Episode = parsedInt;
                 }
             }
         }
@@ -643,7 +645,7 @@ namespace Jellyfin.XmlTv
                 // handle the zero basing!
                 if (int.TryParse(seriesComponents[0], out parsedInt))
                 {
-                    result.Episode.Series = parsedInt + 1;
+                    result.Episode!.Series = parsedInt + 1;
                     if (seriesComponents.Length == 2
                         && int.TryParse(seriesComponents[1], out parsedInt))
                     {
@@ -662,7 +664,7 @@ namespace Jellyfin.XmlTv
                     // handle the zero basing!
                     if (int.TryParse(episodeComponents[0], out parsedInt))
                     {
-                        result.Episode.Episode = parsedInt + 1;
+                        result.Episode!.Episode = parsedInt + 1;
                         if (episodeComponents.Length == 2
                             && int.TryParse(episodeComponents[1], out parsedInt))
                         {
@@ -682,7 +684,7 @@ namespace Jellyfin.XmlTv
                     // handle the zero basing!
                     if (int.TryParse(partComponents[0], out parsedInt))
                     {
-                        result.Episode.Part = parsedInt + 1;
+                        result.Episode!.Part = parsedInt + 1;
                         if (partComponents.Length == 2
                             && int.TryParse(partComponents[1], out parsedInt))
                         {
@@ -748,6 +750,8 @@ namespace Jellyfin.XmlTv
 
         public void ProcessSubTitle(XmlReader reader, XmlTvProgram result)
         {
+            result.Episode ??= new XmlTvEpisode();
+
             /*
             <sub-title lang="en">Gino&apos;s Italian Escape - Islands in the Sun: Southern Sardinia Celebrate the Sea</sub-title>
             <sub-title lang="en">8782</sub-title>

--- a/tests/Jellyfin.XmlTv.Tests/XmlTvReaderTagTests.cs
+++ b/tests/Jellyfin.XmlTv.Tests/XmlTvReaderTagTests.cs
@@ -67,22 +67,40 @@ public class XmlTvReaderTagTests
             },
         };
 
-        [Theory]
-        [MemberData(nameof(GetProgramme_ProcessCategory_SelectsCorrectCategories_TestData))]
-        public void GetProgramme_ProcessCategory_SelectsCorrectCategories(string categoryInput, string? language, string[] expected)
-        {
-            var channel = "channel";
-            var inputString = String.Format(CultureInfo.InvariantCulture, ProgrammeFormat, channel, categoryInput);
+    [Theory]
+    [MemberData(nameof(GetProgramme_ProcessCategory_SelectsCorrectCategories_TestData))]
+    public void GetProgramme_ProcessCategory_SelectsCorrectCategories(string categoryInput, string? language, string[] expected)
+    {
+        var channel = "channel";
+        var inputString = String.Format(CultureInfo.InvariantCulture, ProgrammeFormat, channel, categoryInput);
 
-            var xmlTvReader = new XmlTvReader("file", language);
-            using var reader = XmlReader.Create(new StringReader(inputString));
-            reader.ReadToNextElement();
+        var xmlTvReader = new XmlTvReader("file", language);
+        using var reader = XmlReader.Create(new StringReader(inputString));
+        reader.ReadToNextElement();
 
-            var result = xmlTvReader.GetProgramme(reader, channel, DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
+        var result = xmlTvReader.GetProgramme(reader, channel, DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
 
-            Assert.NotNull(result);
-            Assert.Equal(expected, result!.Categories);
-        }
+        Assert.NotNull(result);
+        Assert.Equal(expected, result!.Categories);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("<category>Thriller</category>")]
+    public void GetProgramme_NoEpisodeTags_NullEpisode(string input)
+    {
+        var channel = "channel";
+        var inputString = String.Format(CultureInfo.InvariantCulture, ProgrammeFormat, channel, input);
+
+        var xmlTvReader = new XmlTvReader("file");
+        using var reader = XmlReader.Create(new StringReader(inputString));
+        reader.ReadToNextElement();
+
+        var result = xmlTvReader.GetProgramme(reader, channel, DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
+
+        Assert.NotNull(result);
+        Assert.Null(result!.Episode);
+    }
 
     [Theory]
     [InlineData("", null, null)]
@@ -100,7 +118,8 @@ public class XmlTvReaderTagTests
         var result = xmlTvReader.GetProgramme(reader, channel, DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
 
         Assert.NotNull(result);
-        Assert.Equal(series, result!.Episode.Series);
+        Assert.NotNull(result!.Episode);
+        Assert.Equal(series, result.Episode!.Series);
         Assert.Equal(episode, result.Episode.Episode);
     }
 
@@ -126,7 +145,8 @@ public class XmlTvReaderTagTests
         var result = xmlTvReader.GetProgramme(reader, channel, DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
 
         Assert.NotNull(result);
-        Assert.Equal(series, result!.Episode.Series);
+        Assert.NotNull(result!.Episode);
+        Assert.Equal(series, result.Episode!.Series);
         Assert.Equal(seriesCount, result.Episode.SeriesCount);
         Assert.Equal(episode, result.Episode.Episode);
         Assert.Equal(episodeCount, result.Episode.EpisodeCount);
@@ -151,12 +171,12 @@ public class XmlTvReaderTagTests
 
         // last one parsed overrides
         Assert.NotNull(result);
-        Assert.Equal(2, result!.Episode.Series);
+        Assert.NotNull(result!.Episode);
+        Assert.Equal(2, result.Episode!.Series);
         Assert.Equal(4, result.Episode.Episode);
     }
 
     [Theory]
-    [InlineData("", null, null)]
     [InlineData("<sub-title>Episode Title</sub-title>", null, "Episode Title")]
     [InlineData("<sub-title lang=\"\">Episode Title</sub-title>", null, "Episode Title")]
     [InlineData("<sub-title lang=\"en\">english</sub-title><sub-title lang=\"es\">spanish</sub-title>", null, "english")]
@@ -175,6 +195,7 @@ public class XmlTvReaderTagTests
         var result = xmlTvReader.GetProgramme(reader, channel, DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
 
         Assert.NotNull(result);
-        Assert.Equal(expected, result!.Episode.Title);
+        Assert.NotNull(result!.Episode);
+        Assert.Equal(expected, result.Episode!.Title);
     }
 }

--- a/tests/Jellyfin.XmlTv.Tests/XmlTvReaderTests.cs
+++ b/tests/Jellyfin.XmlTv.Tests/XmlTvReaderTests.cs
@@ -81,7 +81,7 @@ namespace Jellyfin.XmlTv.Tests
             Assert.Equal("Cameras follow the youngsters' development after two weeks apart and time has made the heart grow fonder for Alfie and Emily, who are clearly happy to be back together. And although Alfie struggled to empathise with the rest of his peers before, a painting competition proves to be a turning point for him. George takes the children's rejection of his family recipe to heart, but goes on to triumph elsewhere, and romance is in the air when newcomer Sienna captures Arthur's heart.", programme.Description);
             Assert.Equal("Documentary", programme.Categories.Single());
             Assert.NotNull(programme.Episode);
-            Assert.Equal("The Secret Life of 5 Year Olds", programme.Episode.Title);
+            Assert.Equal("The Secret Life of 5 Year Olds", programme.Episode!.Title);
             Assert.Equal(1, programme.Episode.Series);
             Assert.Null(programme.Episode.SeriesCount);
             Assert.Equal(4, programme.Episode.Episode);
@@ -177,14 +177,7 @@ namespace Jellyfin.XmlTv.Tests
             Assert.Equal(2, programme.Categories.Count);
             Assert.Equal("Documentales", programme.Categories[0]);
             Assert.Equal("Sociedad", programme.Categories[1]);
-            Assert.NotNull(programme.Episode);
-            Assert.Null(programme.Episode.Episode);
-            Assert.Null(programme.Episode.EpisodeCount);
-            Assert.Null(programme.Episode.Part);
-            Assert.Null(programme.Episode.PartCount);
-            Assert.Null(programme.Episode.Series);
-            Assert.Null(programme.Episode.SeriesCount);
-            Assert.Null(programme.Episode.Title);
+            Assert.Null(programme.Episode);
         }
 
         [Fact]


### PR DESCRIPTION
In Jellyfin [XmlTvListingProvider.cs](https://github.com/jellyfin/jellyfin/blob/5085ae416436a19591ca4e81bf526a06212639ee/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs#L209) checks `Episode` for null to determine if the program is part of a series or not:
```c#
SeasonNumber = program.Episode?.Series,
IsSeries = program.Episode != null,
```

The old code initialized `XmlTvProgram.Episode` to a new `XmlTvEpisode` in the constructor, so it could never be null. This results in Jellyfin treating all programs (movies and shows) as shows ("Record series" button is active, program is recorded to the shows recording directory if set, etc).

Making `Episode` nullable and leaving it null until an episode tag is encountered fixes the behavior in Jellyfin, and besides tests in this repo there was nowhere that uses Episode that doesn't already test it for null.