### PR TITLE
Added support for parsing time offsets with a ':" charachter in them,…

### DIFF
--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -14,8 +14,7 @@ namespace Jellyfin.XmlTv
     // Reads an XmlTv file
     public class XmlTvReader
     {
-        private const string DateWithOffsetRegex = @"^(?<dateDigits>[0-9]{4,14})(\s(?<dateOffset>[+-]*[0-9:]{1,5}))?$";
-        // private const string DateWithOffsetRegex = @"^(?<dateDigits>[0-9]{4,14})(\s(?<dateOffset>[+-]*[0-9]{1,4}))?$";
+        private const string DateWithOffsetRegex = @"^(?<dateDigits>[0-9]{4,14})(\s(?<dateOffset>[+-]*[0-9]{1,2}:{0,1}[0-9]{0,2}))?$";
 
         private readonly string _fileName;
         private readonly string? _language;

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -14,7 +14,8 @@ namespace Jellyfin.XmlTv
     // Reads an XmlTv file
     public class XmlTvReader
     {
-        private const string DateWithOffsetRegex = @"^(?<dateDigits>[0-9]{4,14})(\s(?<dateOffset>[+-]*[0-9]{1,4}))?$";
+        private const string DateWithOffsetRegex = @"^(?<dateDigits>[0-9]{4,14})(\s(?<dateOffset>[+-]*[0-9:]{1,5}))?$";
+        // private const string DateWithOffsetRegex = @"^(?<dateDigits>[0-9]{4,14})(\s(?<dateOffset>[+-]*[0-9]{1,4}))?$";
 
         private readonly string _fileName;
         private readonly string? _language;
@@ -1040,6 +1041,10 @@ namespace Jellyfin.XmlTv
                     if (tmpDateOffset.Length == 5)
                     {
                         dateOffset = tmpDateOffset.Insert(3, ":"); // Add in the colon to ease parsing later
+                    }
+                    else if (tmpDateOffset.Length == 6 && tmpDateOffset.Contains(':', StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        dateOffset = tmpDateOffset;
                     }
                 }
             }

--- a/tests/Jellyfin.XmlTv.Tests/XmlTvReaderDateTimeTests.cs
+++ b/tests/Jellyfin.XmlTv.Tests/XmlTvReaderDateTimeTests.cs
@@ -48,6 +48,8 @@ namespace Jellyfin.XmlTv.Tests
         [InlineData(" ")]
         [InlineData("a")]
         [InlineData("1")]
+        [InlineData("20160101120000 +10:::")]
+
         public void ParseDate_Invalid_Null(string value)
         {
             Assert.Null(XmlTvReader.ParseDate(value));

--- a/tests/Jellyfin.XmlTv.Tests/XmlTvReaderDateTimeTests.cs
+++ b/tests/Jellyfin.XmlTv.Tests/XmlTvReaderDateTimeTests.cs
@@ -15,10 +15,12 @@ namespace Jellyfin.XmlTv.Tests
         [InlineData("01 Jan 2016 12:34:56", "20160101123456")]
         [InlineData("01 Jan 2016 12:00:00", "20160101120000 +0000")]
         [InlineData("01 Jan 2016 02:00:00", "20160101120000 +1000")]
+        [InlineData("01 Jan 2016 02:00:00", "20160101120000 +10:00")]
         [InlineData("01 Jan 2016 11:00:00", "20160101120000 +0100")]
         [InlineData("01 Jan 2016 11:50:00", "20160101120000 +0010")]
         [InlineData("01 Jan 2016 11:59:00", "20160101120000 +0001")]
         [InlineData("01 Jan 2016 22:00:00", "20160101120000 -1000")]
+        [InlineData("01 Jan 2016 22:00:00", "20160101120000 -10:00")]
         [InlineData("01 Jan 2016 13:00:00", "20160101120000 -0100")]
         [InlineData("01 Jan 2016 12:10:00", "20160101120000 -0010")]
         [InlineData("01 Jan 2016 12:01:00", "20160101120000 -0001")]
@@ -33,6 +35,9 @@ namespace Jellyfin.XmlTv.Tests
         [InlineData("01 Jan 2016 12:00:00", "20160101120000 0")]
         public void HandlePartDatesTest(string expected, string value)
         {
+            var date = DateTimeOffset.Parse(expected, styles: DateTimeStyles.AssumeUniversal);
+
+
             Assert.Equal(
                 DateTimeOffset.Parse(expected, styles: DateTimeStyles.AssumeUniversal),
                 XmlTvReader.ParseDate(value));


### PR DESCRIPTION
… e.g. 20160101120000 -10:00

Fix targeting #14 