### PR TITLE
Process program live element

### DIFF
--- a/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
+++ b/src/Jellyfin.XmlTv/Entities/XmlTvProgram.cs
@@ -45,6 +45,8 @@ namespace Jellyfin.XmlTv.Entities
 
         public bool IsNew { get; set; }
 
+        public bool IsLive { get; set; }
+
         public DateTimeOffset? CopyrightDate { get; set; }
 
         public XmlTvEpisode? Episode { get; set; }

--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -222,6 +222,9 @@ namespace Jellyfin.XmlTv
                             case "new":
                                 ProcessNew(xmlProg, result);
                                 break;
+                            case "live":
+                                ProcessLive(xmlProg, result);
+                                break;
                             case "previously-shown":
                                 ProcessPreviouslyShown(xmlProg, result);
                                 break;
@@ -724,6 +727,12 @@ namespace Jellyfin.XmlTv
         public void ProcessNew(XmlReader reader, XmlTvProgram result)
         {
             result.IsNew = true;
+            reader.Skip(); // Move on
+        }
+
+        public void ProcessLive(XmlReader reader, XmlTvProgram result)
+        {
+            result.IsLive = true;
             reader.Skip(); // Move on
         }
 


### PR DESCRIPTION
Although not listed in the XMLTV DTD, program live element is supported by some XMLTV generators (ZAP2XML for example).

This PR processes a live program child element if present and set a new attribute IsLive accordingly.

Possibly Fixes #7 