### PR TITLE
Make XMLTV tags case-insensitive

### DIFF
--- a/src/Jellyfin.XmlTv/XmlTvReader.cs
+++ b/src/Jellyfin.XmlTv/XmlTvReader.cs
@@ -216,7 +216,7 @@ public partial class XmlTvReader
             {
                 if (xmlProg.NodeType == XmlNodeType.Element)
                 {
-                    switch (xmlProg.Name)
+                    switch (xmlProg.Name.ToLower(CultureInfo.CurrentCulture))
                     {
                         case "title":
                             ProcessTitleNode(xmlProg, result);


### PR DESCRIPTION
I found some EPG providers are supplying XML with tags that don't exactly match the DTD.  This is an example EPG item where Jellyfin ignores the sub-title tag because of the case mismatch (Sub-title instead of sub-title).  While the XML is technically out of spec, I think we should still be able to load these tags by making it a case-insensitive match.

`<programme start="20250516040500 +0000" stop="20250516050700 +0000" channel="Global (CIII-DT-41) Toronto.ca"><title>The Late Show With Stephen Colbert</title><Sub-title>Bernie Sanders; Pavement</Sub-title><desc>Sen. Bernie Sanders (I-Vt.); Pavement performs. Guest(s): Bernie Sanders.</desc><episode-num system="xmltv_ns"></episode-num></programme>`